### PR TITLE
Upgrade jsdom dependency and bump for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Since testdom only tries to require jsdom if no document exists; the browser wil
 
 ## Changelog
 
+### 1.0.1
+
+* Upgraded jsdom dependency from 2.x.x to 3.x.x
+
 ### 1.0.0
 
 * Removed non-jsdom dependencies (& globals)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testdom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Testdom helps you write tests for the browser & node",
   "main": "index.js",
   "directories": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/asbjornenge/testdom",
   "dependencies": {
-    "jsdom": "^2.0.0"
+    "jsdom": "^3.1.2"
   },
   "devDependencies": {
     "localStorage": "^1.0.3"


### PR DESCRIPTION
Hey There,

Thanks for putting together this repo - I was thinking of doing the same thing!

All I've done is bumped the version of JSDOM to the latest version that still supports Node (3.x.x supports Node, 4.x.x only supports IO.js).

I've also bumped the version number on testdom, so all you'll have to do once you merge the pull request is npm publish :+1: 

Andrew
