### PR TITLE
Bump jsdom to latest available version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/asbjornenge/testdom",
   "dependencies": {
-    "jsdom": "^13.0.0"
+    "jsdom": "^20.0.0"
   },
   "devDependencies": {
     "localStorage": "^1.0.3",


### PR DESCRIPTION
We are consuming testdom in our package which in turn pulls jsdom@13.0..0 and our security system flagged this version of jsdom. To resolve this issue can we bump jsdom to latest in testdom if it doesn't break anything.